### PR TITLE
fix: update geist font variables

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -11,7 +11,7 @@ const config: Config = {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['var(--font-geist)'],
+        sans: ['var(--font-geist-sans)'],
         mono: ['var(--font-geist-mono)'],
       },
       screens: {


### PR DESCRIPTION
## Summary
- reference Geist Sans font variable in Tailwind config

## Testing
- `pnpm build` *(fails: POSTGRES_URL is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68be13a60d008322a3eadc2655f30ac9