### PR TITLE
feat: add OpenAI chat models

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -157,7 +157,8 @@ export async function POST(request: Request) {
           messages: convertToModelMessages(uiMessages),
           stopWhen: stepCountIs(5),
           experimental_activeTools:
-            selectedChatModel === 'chat-model-reasoning'
+            selectedChatModel === 'chat-model-reasoning' ||
+            selectedChatModel === 'o4-mini'
               ? []
               : [
                   'getWeather',

--- a/app/(chat)/api/chat/schema.ts
+++ b/app/(chat)/api/chat/schema.ts
@@ -21,7 +21,12 @@ export const postRequestBodySchema = z.object({
     role: z.enum(['user']),
     parts: z.array(partSchema),
   }),
-  selectedChatModel: z.enum(['chat-model', 'chat-model-reasoning']),
+  selectedChatModel: z.enum([
+    'chat-model',
+    'chat-model-reasoning',
+    'gpt-4o-mini',
+    'o4-mini',
+  ]),
   selectedVisibilityType: z.enum(['public', 'private']),
 });
 

--- a/lib/ai/entitlements.ts
+++ b/lib/ai/entitlements.ts
@@ -12,7 +12,12 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    */
   guest: {
     maxMessagesPerDay: 20,
-    availableChatModelIds: ['chat-model', 'chat-model-reasoning'],
+    availableChatModelIds: [
+      'chat-model',
+      'chat-model-reasoning',
+      'gpt-4o-mini',
+      'o4-mini',
+    ],
   },
 
   /*
@@ -20,7 +25,12 @@ export const entitlementsByUserType: Record<UserType, Entitlements> = {
    */
   regular: {
     maxMessagesPerDay: 100,
-    availableChatModelIds: ['chat-model', 'chat-model-reasoning'],
+    availableChatModelIds: [
+      'chat-model',
+      'chat-model-reasoning',
+      'gpt-4o-mini',
+      'o4-mini',
+    ],
   },
 
   /*

--- a/lib/ai/models.ts
+++ b/lib/ai/models.ts
@@ -17,4 +17,15 @@ export const chatModels: Array<ChatModel> = [
     name: 'Grok Reasoning',
     description: 'Uses advanced chain-of-thought reasoning for complex problems',
   },
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o mini',
+    description: 'OpenAI’s lightweight GPT-4o model for fast multimodal responses',
+  },
+  {
+    id: 'o4-mini',
+    name: 'O4 mini',
+    description:
+      'OpenAI reasoning model optimized for step-by-step problem solving',
+  },
 ];

--- a/lib/ai/prompts.ts
+++ b/lib/ai/prompts.ts
@@ -59,7 +59,10 @@ export const systemPrompt = ({
 }) => {
   const requestPrompt = getRequestPromptFromHints(requestHints);
 
-  if (selectedChatModel === 'chat-model-reasoning') {
+  if (
+    selectedChatModel === 'chat-model-reasoning' ||
+    selectedChatModel === 'o4-mini'
+  ) {
     return `${regularPrompt}\n\n${requestPrompt}`;
   } else {
     return `${regularPrompt}\n\n${requestPrompt}\n\n${artifactsPrompt}`;

--- a/lib/ai/providers.ts
+++ b/lib/ai/providers.ts
@@ -17,6 +17,8 @@ export const myProvider = isTestEnvironment
       languageModels: {
         'chat-model': chatModel,
         'chat-model-reasoning': reasoningModel,
+        'gpt-4o-mini': chatModel,
+        'o4-mini': reasoningModel,
         'title-model': titleModel,
         'artifact-model': artifactModel,
       },
@@ -27,6 +29,11 @@ export const myProvider = isTestEnvironment
         'chat-model-reasoning': wrapLanguageModel({
           model: gateway.languageModel('xai/grok-3-mini-beta'),
           middleware: extractReasoningMiddleware({ tagName: 'think' }),
+        }),
+        'gpt-4o-mini': gateway.languageModel('openai/gpt-4o-mini'),
+        'o4-mini': wrapLanguageModel({
+          model: gateway.languageModel('openai/o4-mini'),
+          middleware: extractReasoningMiddleware({ tagName: 'reasoning' }),
         }),
         'title-model': gateway.languageModel('xai/grok-2-1212'),
         'artifact-model': gateway.languageModel('xai/grok-2-1212'),

--- a/tests/e2e/model-selector.test.ts
+++ b/tests/e2e/model-selector.test.ts
@@ -1,0 +1,19 @@
+import { ChatPage } from '../pages/chat';
+import { test, expect } from '../fixtures';
+
+// Ensure the model selector lists newly added OpenAI models
+
+test.describe('Model selector', () => {
+  test('shows OpenAI models', async ({ page }) => {
+    const chatPage = new ChatPage(page);
+    await chatPage.createNewChat();
+
+    await page.getByTestId('model-selector').click();
+    await expect(
+      page.getByTestId('model-selector-item-gpt-4o-mini'),
+    ).toBeVisible();
+    await expect(
+      page.getByTestId('model-selector-item-o4-mini'),
+    ).toBeVisible();
+  });
+});

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -24,7 +24,11 @@ export async function createAuthenticatedContext({
 }: {
   browser: Browser;
   name: string;
-  chatModel?: 'chat-model' | 'chat-model-reasoning';
+  chatModel?:
+    | 'chat-model'
+    | 'chat-model-reasoning'
+    | 'gpt-4o-mini'
+    | 'o4-mini';
 }): Promise<UserContext> {
   const directory = path.join(__dirname, '../playwright/.sessions');
 


### PR DESCRIPTION
## Summary
- add OpenAI model definitions and entitlements
- wire OpenAI models into provider and prompts
- cover new models in the model selector test

## Testing
- `pnpm lint`
- `pnpm test` *(fails: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1161/chrome-linux/headless_shell)*


------
https://chatgpt.com/codex/tasks/task_e_68bf9cf0536c8322b6ad2a4e4fa326a5