### PR TITLE
feat: include original messages and IDs in chat UI stream

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -237,6 +237,8 @@ export async function POST(request: Request) {
         dataStream.merge(
           result.toUIMessageStream({
             sendReasoning: true,
+            originalMessages: uiMessages,
+            generateMessageId: generateUUID,
           }),
         );
       },


### PR DESCRIPTION
## Summary
- forward original messages when streaming UI responses
- assign consistent IDs for streamed messages

## Testing
- `pnpm lint`
- `pnpm run typecheck`
- `OPENAI_API_KEY=sk-test pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c05e8eb8208322881868b23e3dd269