### PR TITLE
Use crypto.randomUUID for UUID generation

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -59,11 +59,10 @@ export function generateUUID(): string {
   if (typeof globalThis.crypto?.randomUUID === 'function') {
     return globalThis.crypto.randomUUID();
   }
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-    const r = (Math.random() * 16) | 0;
-    const v = c === 'x' ? r : (r & 0x3) | 0x8;
-    return v.toString(16);
-  });
+
+  return (
+    Function('return require')()('node:crypto') as typeof import('node:crypto')
+  ).randomUUID();
 }
 
 type ResponseMessageWithoutId = CoreToolMessage | CoreAssistantMessage;


### PR DESCRIPTION
## Summary
- replace Math.random fallback with crypto.randomUUID, using Node's crypto when Web Crypto isn't available

## Testing
- `pnpm lint`
- `pnpm run typecheck`
- `OPENAI_API_KEY=sk-test pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c07e13d990832289a793dce8a5ecf8