### PR TITLE
feat: add message upsert helper

### DIFF
--- a/app/(chat)/api/chat/route.ts
+++ b/app/(chat)/api/chat/route.ts
@@ -20,6 +20,7 @@ import { geolocation } from '@vercel/functions';
 import { ChatSDKError } from '@/lib/errors';
 import type { ChatMessage } from '@/lib/types';
 import type { VisibilityType } from '@/components/visibility-selector';
+import { upsertMessage } from '@/hooks/messages-reducer';
 
 export const runtime = 'nodejs';
 
@@ -119,7 +120,10 @@ export async function POST(request: Request) {
     }
 
     const messagesFromDb = await getMessagesByChatId({ id });
-    const messages = [...convertToUIMessages(messagesFromDb), message];
+    const messages = upsertMessage(
+      convertToUIMessages(messagesFromDb),
+      message,
+    );
 
     const { longitude, latitude, city, country } = geolocation(request);
 

--- a/hooks/messages-reducer.ts
+++ b/hooks/messages-reducer.ts
@@ -1,0 +1,33 @@
+import type { ChatMessage } from '@/lib/types';
+
+export function upsertMessage(
+  list: ChatMessage[],
+  incoming: ChatMessage,
+): ChatMessage[] {
+  const id = incoming.id ?? crypto.randomUUID();
+  const index = list.findIndex((m) => m.id === id);
+  const message: ChatMessage = { ...incoming, id };
+
+  if (index !== -1) {
+    const existing = list[index] as ChatMessage & { toolInvocations?: any[] };
+    const incomingWithTools = message as ChatMessage & { toolInvocations?: any[] };
+
+    const merged: ChatMessage & { toolInvocations?: any[] } = {
+      ...existing,
+      ...incomingWithTools,
+      parts: [...(existing.parts ?? []), ...(incomingWithTools.parts ?? [])],
+      ...(existing.toolInvocations || incomingWithTools.toolInvocations
+        ? {
+            toolInvocations: [
+              ...(existing.toolInvocations ?? []),
+              ...(incomingWithTools.toolInvocations ?? []),
+            ],
+          }
+        : {}),
+    };
+
+    return [...list.slice(0, index), merged, ...list.slice(index + 1)];
+  }
+
+  return [...list, message];
+}

--- a/hooks/use-auto-resume.ts
+++ b/hooks/use-auto-resume.ts
@@ -4,6 +4,7 @@ import { useEffect, useRef } from 'react';
 import type { UseChatHelpers } from '@ai-sdk/react';
 import type { ChatMessage } from '@/lib/types';
 import { useDataStream } from '@/components/data-stream-provider';
+import { upsertMessage } from './messages-reducer';
 
 export interface UseAutoResumeParams {
   autoResume: boolean;
@@ -46,16 +47,7 @@ export function useAutoResume({
         if (processed.current.has(key)) continue;
         processed.current.add(key);
 
-        setMessages((prev) => {
-          const idx = prev.findIndex((m) => m.id === message.id);
-          if (idx === -1) {
-            return [...prev, message];
-          }
-
-          const updated = [...prev];
-          updated[idx] = message;
-          return updated;
-        });
+        setMessages((prev) => upsertMessage(prev, message));
       } catch {
         // ignore malformed JSON
       }

--- a/hooks/use-messages.tsx
+++ b/hooks/use-messages.tsx
@@ -1,3 +1,4 @@
+
 import { useState, useEffect } from 'react';
 import { useScrollToBottom } from './use-scroll-to-bottom';
 import type { UseChatHelpers } from '@ai-sdk/react';


### PR DESCRIPTION
## Summary
- add `upsertMessage` helper to merge incoming chat messages by id
- use helper in auto-resume hook and chat API route to prevent duplicates

## Testing
- `pnpm lint`
- `pnpm run typecheck`
- `OPENAI_API_KEY=sk-test pnpm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c07e0dc9848322a39586ce0e10a79b